### PR TITLE
Incomplete join on query using course_modules

### DIFF
--- a/classes/moodle/synchronize.php
+++ b/classes/moodle/synchronize.php
@@ -400,7 +400,7 @@ class synchronize {
                   JOIN {'.\pmclass::TABLE.'} cls ON cls.courseid = cmp.courseid
                   JOIN {'.\classmoodlecourse::TABLE.'} cmc ON cmc.classid = cls.id
                        AND cmc.moodlecourseid > 0 '.$courseidssql.'
-             LEFT JOIN {course_modules} crsmod ON crsmod.idnumber = cmp.idnumber
+             LEFT JOIN {course_modules} crsmod ON crsmod.idnumber = cmp.idnumber AND crsmod.course = cmc.moodlecourseid
              LEFT JOIN {grade_items} gi
                            ON gi.courseid = cmc.moodlecourseid
                            AND (gi.idnumber = cmp.idnumber OR gi.idnumber = crsmod.id)';


### PR DESCRIPTION
The course_modules join is incomplete. It would work only if idnumber were a unique index, but the index requires course,idnumber to be unique. In an application where module idnumbers are repeated (for example when courses are being cloned) this results in incorrect joins, large result size and possible connection aborts. The fix is to require a match on both idnumber and course.